### PR TITLE
SV-32 Bump to latest docker-cra with cache fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM demery/docker-cra:v0.1.2
+FROM demery/docker-cra:v0.1.3
 
 COPY env.schema.js ./env.schema.js
 COPY build /usr/share/nginx/html

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@types/react": "^17.0.37",
         "@types/react-dom": "^17.0.11",
         "axios": "^0.24.0",
-        "docker-cra": "0.1.2",
+        "docker-cra": "0.1.3",
         "formik": "^2.2.9",
         "joi": "^17.5.0",
         "pluralize": "^8.0.0",
@@ -9990,9 +9990,9 @@
       }
     },
     "node_modules/docker-cra": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/docker-cra/-/docker-cra-0.1.2.tgz",
-      "integrity": "sha512-4vDvKk7g+KiU2UgTtWNOsCf+4cvi6t9/7TbR+WdfbOcv8cF0Qh21fKZ2BrvQ4lV8EulLmx5VIxlGRffrpi3QbQ==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/docker-cra/-/docker-cra-0.1.3.tgz",
+      "integrity": "sha512-O+b2DSldhT/MNIC0o2UprThUFQnA4TF6yNJO7VsqJKxgY4hRGrW+yBg2jRe4UfRsL+p0HKkAqtRrcDGBffPLlQ==",
       "dependencies": {
         "commander": "^8.3.0",
         "dotenv": "^10.0.0",
@@ -33884,9 +33884,9 @@
       }
     },
     "docker-cra": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/docker-cra/-/docker-cra-0.1.2.tgz",
-      "integrity": "sha512-4vDvKk7g+KiU2UgTtWNOsCf+4cvi6t9/7TbR+WdfbOcv8cF0Qh21fKZ2BrvQ4lV8EulLmx5VIxlGRffrpi3QbQ==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/docker-cra/-/docker-cra-0.1.3.tgz",
+      "integrity": "sha512-O+b2DSldhT/MNIC0o2UprThUFQnA4TF6yNJO7VsqJKxgY4hRGrW+yBg2jRe4UfRsL+p0HKkAqtRrcDGBffPLlQ==",
       "requires": {
         "commander": "^8.3.0",
         "dotenv": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
     "axios": "^0.24.0",
-    "docker-cra": "0.1.2",
+    "docker-cra": "0.1.3",
     "formik": "^2.2.9",
     "joi": "^17.5.0",
     "pluralize": "^8.0.0",


### PR DESCRIPTION
- Use latest `docker-cra` which adds a hash to the `window.env.js` filename to invalidate cache on changes